### PR TITLE
Abstract out file store from data tracker

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/ant0ine/go-json-rest/rest"
-	dhcp "github.com/krolaw/dhcp4"
 	"log"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/ant0ine/go-json-rest/rest"
+	dhcp "github.com/krolaw/dhcp4"
 )
 
 /*
@@ -83,13 +84,13 @@ type Frontend struct {
 	cfg      Config
 }
 
-func NewFrontend(data_dir, cert_pem, key_pem string, cfg Config) *Frontend {
+func NewFrontend(cert_pem, key_pem string, cfg Config, store LoadSaver) *Frontend {
 	fe := &Frontend{
 		data_dir: data_dir,
 		cert_pem: cert_pem,
 		key_pem:  key_pem,
 		cfg:      cfg,
-		DhcpInfo: NewDataTracker(data_dir),
+		DhcpInfo: NewDataTracker(store),
 	}
 
 	fe.DhcpInfo.load_data()

--- a/api_test.go
+++ b/api_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func base_url(path string) string {
@@ -17,7 +19,11 @@ func get_frontend() (*Frontend, http.Handler) {
 	cfg.Network.Port = 6755
 	cfg.Network.Username = "fred"
 	cfg.Network.Password = "rules"
-	the_fe := NewFrontend(".", "", "", cfg)
+	fs, err := NewFileStore("./database.json")
+	if err != nil {
+		log.Panic(err)
+	}
+	the_fe := NewFrontend("", "", cfg, fs)
 	handler := the_fe.RunServer(false)
 	return the_fe, handler
 }

--- a/api_test.go
+++ b/api_test.go
@@ -19,7 +19,7 @@ func get_frontend() (*Frontend, http.Handler) {
 	cfg.Network.Port = 6755
 	cfg.Network.Username = "fred"
 	cfg.Network.Password = "rules"
-	fs, err := NewFileStore("./database.json")
+	fs, err := NewFileStore("./database.test.json")
 	if err != nil {
 		log.Panic(err)
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -1,16 +1,17 @@
 package main
 
 import (
-	dhcp "github.com/krolaw/dhcp4"
-	"github.com/stretchr/testify/assert"
+	"log"
 	"net"
 	"net/http"
 	"testing"
+
+	dhcp "github.com/krolaw/dhcp4"
+	"github.com/stretchr/testify/assert"
 )
 
 func newSubnet(dt *DataTracker, name, subnet string) (s *Subnet) {
 	_, theNet, _ := net.ParseCIDR(subnet)
-
 	s = NewSubnet()
 	s.Name = name
 	s.Subnet = &MyIPNet{theNet}
@@ -26,7 +27,11 @@ func addNewSubnet(dt *DataTracker, name, subnet string) (s *Subnet, err error, c
 }
 
 func simpleSetup() (dt *DataTracker, s *Subnet) {
-	dt = NewDataTracker(".")
+	store, err := NewFileStore("./database.test.json")
+	if err != nil {
+		log.Panic(err)
+	}
+	dt = NewDataTracker(store)
 	s, _, _ = addNewSubnet(dt, "fred", "192.168.128.0/24")
 	dt.AddSubnet(s)
 	return
@@ -155,7 +160,11 @@ func TestReplaceSubnetMustNotOverlap(t *testing.T) {
 }
 
 func TestFindSubnetEmpty(t *testing.T) {
-	dt := NewDataTracker(".")
+	store, err := NewFileStore("./database.test.json")
+	if err != nil {
+		log.Panic(err)
+	}
+	dt := NewDataTracker(store)
 
 	s := dt.FindSubnet(net.ParseIP("0.0.0.0"))
 	assert.Nil(t, s, "Expected nil subnets")

--- a/database.test.json
+++ b/database.test.json
@@ -1,0 +1,1 @@
+{"Subnets":{"fred":{"name":"fred","subnet":"192.168.128.0/24","active_start":"192.168.128.5","active_end":"192.168.128.25","active_lease_time":0,"reserved_lease_time":0}}}

--- a/rebar-dhcp.go
+++ b/rebar-dhcp.go
@@ -36,11 +36,14 @@ func main() {
 	if cerr != nil {
 		log.Fatal(cerr)
 	}
-
-	fe := NewFrontend(data_dir, cert_pem, key_pem, cfg)
-
-	err := StartDhcpHandlers(fe.DhcpInfo, server_ip)
+	fs, err := NewFileStore(data_dir + "/database.json")
 	if err != nil {
+		log.Fatal(err)
+	}
+
+	fe := NewFrontend(cert_pem, key_pem, cfg, fs)
+
+	if err := StartDhcpHandlers(fe.DhcpInfo, server_ip); err != nil {
 		log.Fatal(err)
 	}
 	fe.RunServer(true)

--- a/stores.go
+++ b/stores.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+type LoadSaver interface {
+	Save(*DataTracker) error
+	Load(*DataTracker) error
+}
+
+type FileStore struct {
+	backingDatabase string
+}
+
+func NewFileStore(dbFile string) (*FileStore, error) {
+	info, err := os.Stat(dbFile)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", dbFile)
+	}
+	return &FileStore{backingDatabase: dbFile}, nil
+}
+
+func (fs *FileStore) Save(dt *DataTracker) error {
+	dt.Lock()
+	defer dt.Unlock()
+	data, err := json.Marshal(dt)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(fs.backingDatabase, data, 0700); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (fs *FileStore) Load(dt *DataTracker) error {
+	dt.Lock()
+	defer dt.Unlock()
+	data, err := ioutil.ReadFile(fs.backingDatabase)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dt)
+}


### PR DESCRIPTION
This creates an abstraction layer that we can use to allow an arbitrary KV store to act as a backend.
