### PR TITLE
Update link for gcfg

### DIFF
--- a/rebar-dhcp.go
+++ b/rebar-dhcp.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 )
 
 type Config struct {


### PR DESCRIPTION
gcfg migrated from [code.google.com/p/gcfg](https://code.google.com/archive/p/gcfg/) to [gopkg.in/gcfg.v1](https://gopkg.in/gcfg.v1).

It not work correct now with old link - 

```
go get github.com/galthaus/ocb-dhcp
package code.google.com/p/gcfg: unable to detect version control system for code.google.com/ path
```
